### PR TITLE
bug fix: changed way get_open_uniform() keywords are input to be in l…

### DIFF
--- a/lsdo_geo/splines/b_splines/b_spline_space.py
+++ b/lsdo_geo/splines/b_splines/b_spline_space.py
@@ -36,7 +36,7 @@ class BSplineSpace(m3l.FunctionSpace):
             for i in range(self.num_parametric_dimensions):
                 num_knots = self.order[i] + self.parametric_coefficients_shape[i]
                 knots_i = np.zeros((num_knots,))
-                get_open_uniform(order=self.order[i], num_coefficients=self.parametric_coefficients_shape[i], knot_vector=knots_i)
+                get_open_uniform(self.order[i], self.parametric_coefficients_shape[i], knots_i)
                 self.knot_indices.append(np.arange(len(self.knots), len(self.knots) + num_knots))
                 self.knots = np.hstack((self.knots, knots_i))
         else:


### PR DESCRIPTION
…ine with other places where get_open_uniform() is called

## Summary
### Overview
I made a minor update to the one place where get_open_uniform() is still being called with an outdated way of specifying its arguments (i.e. get_open_uniform(order=self.order[i], num_coefficients=self.parametric_coefficients_shape[i], knot_vector=knots_i)). This has been changed everywhere else already.

### Context
This specific code is called when running the FEMO-M3L PAV validation case.